### PR TITLE
Update issue-2722.ttl

### DIFF
--- a/data/ext/pending/issue-2722.ttl
+++ b/data/ext/pending/issue-2722.ttl
@@ -8,14 +8,6 @@
     :category "issue-2722" ;
     :isPartOf <http://pending.schema.org> ;
     :source <https://github.com/schemaorg/schemaorg/issues/2722> ;
-    rdfs:comment "This is the markup to tell the search engine how the video websites encode timestamp in their URL format." ;
+    rdfs:comment "The [[Action]] of navigating to a specific [[startOffset]] timestamp within a [[VideoObject]], typically represented with a URL template structure." ;
     rdfs:subClassOf :Action .
     
-:startOffset-input a rdf:Property ;
-    rdfs:label "startOffset-input" ;
-    :category "issue-2722" ;
-    :domainIncludes :SeekToAction ;
-    :isPartOf <http://pending.schema.org> ;
-    :rangeIncludes :Text ;
-    :source <https://github.com/schemaorg/schemaorg/issues/2722> ;
-    rdfs:comment "The timestamp value to be filled in the target. For example: “required name=seek_to_second_number" .


### PR DESCRIPTION
Couple of suggestions:  drop the pseudo-property; it is implied by the schema.org [actions](http://schema.org/docs/actions.html) spec, and reword the definition to be more declarative rather than assuming a particular (search) processing model.

(I tried to comment on your PR draft and it made me make a PR on your PR, which is nuts but there you go!:)